### PR TITLE
debuggerd: Disable scudo usage

### DIFF
--- a/debuggerd/Android.bp
+++ b/debuggerd/Android.bp
@@ -249,13 +249,6 @@ cc_library_static {
         debuggable: {
             cflags: ["-DROOT_POSSIBLE"],
         },
-
-        malloc_not_svelte: {
-            cflags: ["-DUSE_SCUDO"],
-            whole_static_libs: ["libscudo"],
-            srcs: ["libdebuggerd/scudo.cpp"],
-            header_libs: ["scudo_headers"],
-        },
     },
 }
 


### PR DESCRIPTION
Since we have switched to jemalloc (bionic).