### PR TITLE
liblp: Allow to flash on bigger block device

### DIFF
--- a/fs_mgr/liblp/writer.cpp
+++ b/fs_mgr/liblp/writer.cpp
@@ -138,8 +138,8 @@ static bool ValidateAndSerializeMetadata([[maybe_unused]] const IPartitionOpener
             PERROR << partition_name << ": ioctl";
             return false;
         }
-        if (info.size != block_device.size) {
-            LERROR << "Block device " << partition_name << " size mismatch (expected"
+        if (info.size < block_device.size) {
+            LERROR << "Block device " << partition_name << " size is too small (expected"
                    << block_device.size << ", got " << info.size << ")";
             return false;
         }


### PR DESCRIPTION
Needed for using Retrofit Dynamic Partitions on unified targets, which has different partition sizes on different devices.

Change-Id: I2b4c05401569ce5fc301ebafa7d130c3b0d87c64

Former-commit-id: 7f411c6cc145a7d814a324a9db9ba5ba00a58f2b